### PR TITLE
chore: use the debug build tag and bump actions to v7

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # We must fetch at least the immediate parents so that if this is
           # a pull request then we can checkout the head.

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Go
         uses: actions/setup-go@v7 # action page: <https://github.com/actions/setup-go>

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -26,7 +26,7 @@ jobs:
           go-version: ${{ matrix.go }}
 
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Init Go modules Cache # Docs: <https://git.io/JfAKn#go---modules>
         uses: actions/cache@v5
@@ -42,7 +42,7 @@ jobs:
         run: |
           mkdir -p ./coverage-ci
 
-          go test -timeout 10m -v -race -cover -failfast \
+          go test -timeout 10m -v -race -cover -tags=debug \
             -coverpkg=github.com/roadrunner-server/static/v6/... \
             -coverprofile=./coverage-ci/root.out \
             -covermode=atomic ./...
@@ -51,7 +51,7 @@ jobs:
         run: |
           cd tests
 
-          go test -timeout 10m -v -race -cover -failfast \
+          go test -timeout 10m -v -race -cover -tags=debug \
             -coverpkg=github.com/roadrunner-server/static/v6/... \
             -coverprofile=../coverage-ci/integration.out \
             -covermode=atomic ./...
@@ -70,7 +70,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Download code coverage results
         uses: actions/download-artifact@v8
@@ -91,7 +91,7 @@ jobs:
           mv summary.filtered.txt summary.txt
 
       - name: Upload to codecov
-        uses: codecov/codecov-action@v6 # Docs: <https://github.com/codecov/codecov-action>
+        uses: codecov/codecov-action@v7 # Docs: <https://github.com/codecov/codecov-action>
         with:
           files: summary.txt
           fail_ci_if_error: false


### PR DESCRIPTION
Two unrelated CI tidy-ups.

Adds `-tags=debug` to both test steps. `roadrunner-server/errors` splits on the tag — `debug_cap.go` is `//go:build !debug` and makes `populateStack`/`printStack` no-ops, while `debug_stack.go` captures the caller chain and prints `file:line: func` per frame. Without it a failure shows a bare error string. Verified `go test -tags=debug ./...` passes locally.

Drops `-failfast`, which hides every failure after the first.

Bumps `codecov-action` and `actions/checkout` from v6 to v7 to match the rest of the fleet.
