### PR TITLE
chore: cover the untested branches

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -89,6 +89,12 @@ jobs:
             }
           ' summary.txt > summary.filtered.txt
           mv summary.filtered.txt summary.txt
+          # a profile that maps to no plugin source uploads fine and reports 0%
+          blocks=$(($(wc -l < summary.txt) - 1))
+          if [ "$blocks" -lt 10 ]; then
+            echo "::error::coverage summary holds $blocks blocks, the profile does not map to plugin sources"
+            exit 1
+          fi
 
       - name: Upload to codecov
         uses: codecov/codecov-action@v7 # Docs: <https://github.com/codecov/codecov-action>

--- a/etag_test.go
+++ b/etag_test.go
@@ -1,0 +1,63 @@
+package static
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// openFile writes content into a temp dir and opens it through http.Dir, which
+// is what the plugin hands SetEtag at runtime.
+func openFile(t *testing.T, content string) http.File {
+	t.Helper()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "f.txt"), []byte(content), 0o600))
+
+	f, err := http.Dir(dir).Open("/f.txt")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = f.Close() })
+
+	return f
+}
+
+// TestSetEtagWeakUsesNameNotContent checks the weak form is derived from the
+// file name, so two files with different content share an etag.
+func TestSetEtagWeakUsesNameNotContent(t *testing.T) {
+	first := httptest.NewRecorder()
+	SetEtag(true, openFile(t, "one"), "same-name.txt", first)
+
+	second := httptest.NewRecorder()
+	SetEtag(true, openFile(t, "a different body"), "same-name.txt", second)
+
+	got := first.Header().Get("Etag")
+	require.NotEmpty(t, got)
+	require.True(t, len(got) > 2 && got[:2] == "W/", "weak etag must carry the W/ prefix, got %q", got)
+	require.Equal(t, got, second.Header().Get("Etag"))
+}
+
+// TestSetEtagStrongUsesContent checks the strong form changes with the body.
+func TestSetEtagStrongUsesContent(t *testing.T) {
+	first := httptest.NewRecorder()
+	SetEtag(false, openFile(t, "one"), "f.txt", first)
+
+	second := httptest.NewRecorder()
+	SetEtag(false, openFile(t, "another"), "f.txt", second)
+
+	require.NotEmpty(t, first.Header().Get("Etag"))
+	require.NotEqual(t, first.Header().Get("Etag"), second.Header().Get("Etag"))
+}
+
+// TestSetEtagSkipsEmptyBody covers the early return: an empty file gets no etag
+// at all rather than an etag over zero bytes.
+func TestSetEtagSkipsEmptyBody(t *testing.T) {
+	rec := httptest.NewRecorder()
+
+	SetEtag(false, openFile(t, ""), "empty.txt", rec)
+
+	require.Empty(t, rec.Header().Get("Etag"))
+}

--- a/init_test.go
+++ b/init_test.go
@@ -1,0 +1,123 @@
+package static
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/roadrunner-server/errors"
+	"github.com/stretchr/testify/require"
+)
+
+// stubConfigurer hands Init a pre-built Config instead of decoding YAML.
+type stubConfigurer struct {
+	sections map[string]bool
+	cfg      *Config
+	err      error
+}
+
+func (s *stubConfigurer) Has(name string) bool { return s.sections[name] }
+
+func (s *stubConfigurer) UnmarshalKey(_ string, out any) error {
+	if s.err != nil {
+		return s.err
+	}
+
+	p, ok := out.(**Config)
+	if !ok {
+		return errors.Str("unexpected target type")
+	}
+	*p = s.cfg
+	return nil
+}
+
+type discardLogger struct{}
+
+func (discardLogger) NamedLogger(string) *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func bothSections() map[string]bool {
+	return map[string]bool{RootPluginName: true, cfgKey: true}
+}
+
+func TestInitDisabledWithoutHTTPSection(t *testing.T) {
+	err := (&Plugin{}).Init(&stubConfigurer{sections: map[string]bool{}}, discardLogger{})
+
+	require.Error(t, err)
+	require.True(t, errors.Is(errors.Disabled, err))
+}
+
+func TestInitDisabledWithoutStaticSection(t *testing.T) {
+	err := (&Plugin{}).Init(&stubConfigurer{sections: map[string]bool{RootPluginName: true}}, discardLogger{})
+
+	require.Error(t, err)
+	require.True(t, errors.Is(errors.Disabled, err))
+}
+
+func TestInitDisabledWhenUnmarshalFails(t *testing.T) {
+	c := &stubConfigurer{sections: bothSections(), err: errors.Str("broken config")}
+
+	err := (&Plugin{}).Init(c, discardLogger{})
+
+	require.Error(t, err)
+	require.True(t, errors.Is(errors.Disabled, err))
+}
+
+func TestInitRejectsMissingRootDirectory(t *testing.T) {
+	c := &stubConfigurer{sections: bothSections(), cfg: &Config{Dir: filepath.Join(t.TempDir(), "absent")}}
+
+	err := (&Plugin{}).Init(c, discardLogger{})
+
+	require.ErrorContains(t, err, "does not exists")
+}
+
+func TestInitRejectsFileAsRootDirectory(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "a-file")
+	require.NoError(t, os.WriteFile(file, []byte("x"), 0o600))
+
+	c := &stubConfigurer{sections: bothSections(), cfg: &Config{Dir: file}}
+
+	err := (&Plugin{}).Init(c, discardLogger{})
+
+	require.ErrorContains(t, err, "invalid root directory")
+}
+
+// TestInitDropsForbiddenFromAllowed covers the reconciliation step: an extension
+// listed in both lists must not survive in the allowed set.
+func TestInitDropsForbiddenFromAllowed(t *testing.T) {
+	p := &Plugin{}
+	c := &stubConfigurer{sections: bothSections(), cfg: &Config{
+		Dir:    t.TempDir(),
+		Allow:  []string{".txt", ".css", "", ".js"},
+		Forbid: []string{".js", ""},
+	}}
+
+	require.NoError(t, p.Init(c, discardLogger{}))
+
+	require.Contains(t, p.allowedExtensions, ".txt")
+	require.Contains(t, p.allowedExtensions, ".css")
+	require.NotContains(t, p.allowedExtensions, ".js")
+	require.Contains(t, p.forbiddenExtensions, ".js")
+
+	// the empty entries in both lists are skipped rather than stored
+	require.NotContains(t, p.allowedExtensions, "")
+	require.NotContains(t, p.forbiddenExtensions, "")
+}
+
+func TestName(t *testing.T) {
+	require.Equal(t, PluginName, (&Plugin{}).Name())
+}
+
+func TestBytesToStrEmpty(t *testing.T) {
+	require.Empty(t, bytesToStr(nil))
+	require.Empty(t, bytesToStr([]byte{}))
+	require.Equal(t, "abc", bytesToStr([]byte("abc")))
+}
+
+func TestStrToBytesEmpty(t *testing.T) {
+	require.Nil(t, strToBytes(""))
+	require.Equal(t, []byte("abc"), strToBytes("abc"))
+}

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -1,0 +1,91 @@
+package static
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// servePlugin builds a plugin over dir with the given allow/forbid lists and
+// returns its middleware plus a flag reporting whether the request fell through
+// to the next handler.
+func servePlugin(t *testing.T, dir string, allow, forbid []string) (http.Handler, *atomic.Bool) {
+	t.Helper()
+
+	p := &Plugin{}
+	c := &stubConfigurer{
+		sections: bothSections(),
+		cfg:      &Config{Dir: dir, Allow: allow, Forbid: forbid},
+	}
+	require.NoError(t, p.Init(c, discardLogger{}))
+
+	var fellThrough atomic.Bool
+	h := p.Middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fellThrough.Store(true)
+		w.WriteHeader(http.StatusTeapot)
+	}))
+
+	return h, &fellThrough
+}
+
+// requestPath drives one request through the middleware and returns the status
+// the recorder captured, so no response body is left open.
+func requestPath(t *testing.T, h http.Handler, path string) int {
+	t.Helper()
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, path, nil))
+
+	resp := rec.Result()
+	require.NoError(t, resp.Body.Close())
+
+	return resp.StatusCode
+}
+
+// TestExtensionOutsideAllowListFallsThrough covers the branch where an allow
+// list exists and the requested extension is not on it: static declines and the
+// worker handles the request.
+func TestExtensionOutsideAllowListFallsThrough(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "image.png"), []byte("not-really-a-png"), 0o600))
+
+	h, fellThrough := servePlugin(t, dir, []string{".txt"}, nil)
+
+	status := requestPath(t, h, "/image.png")
+
+	require.True(t, fellThrough.Load(), "request should have reached the worker")
+	require.Equal(t, http.StatusTeapot, status)
+}
+
+// TestDirectoryRequestFallsThrough covers the IsDir branch: a path pointing at a
+// directory is never served, it goes to the worker.
+func TestDirectoryRequestFallsThrough(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "assets"), 0o750))
+
+	h, fellThrough := servePlugin(t, dir, nil, nil)
+
+	status := requestPath(t, h, "/assets")
+
+	require.True(t, fellThrough.Load(), "a directory must not be served")
+	require.Equal(t, http.StatusTeapot, status)
+}
+
+// TestAllowedExtensionIsServed is the positive counterpart: the file is written
+// by static and never reaches the worker.
+func TestAllowedExtensionIsServed(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "hello.txt"), []byte("hello world"), 0o600))
+
+	h, fellThrough := servePlugin(t, dir, []string{".txt"}, nil)
+
+	status := requestPath(t, h, "/hello.txt")
+
+	require.False(t, fellThrough.Load(), "static should have served the file itself")
+	require.Equal(t, http.StatusOK, status)
+}


### PR DESCRIPTION
Wave 2, but a smaller change than the other middlewares because static did not need the usual overhaul.

Its suite already avoided the endure boilerplate and had **zero** `time.Sleep` calls — it drives the middleware directly through `httptest` with in-memory YAML and `t.TempDir`. Restructuring it would have been churn, so this closes the coverage gaps instead.

Merged coverage went from 83.7% to **94.3%** (badge is 74%). What was uncovered and now is not:

- `Init`: both disabled paths, the unmarshal failure, a missing root directory, a file passed where a directory is expected, and the reconciliation step that drops an extension appearing in both `allow` and `forbid`
- `Middleware`: an extension outside a non-empty allow list falls through to the worker, a directory path is never served, and an allowed file is served by static rather than PHP
- `SetEtag`: the weak form keys on the file name (two different bodies share an etag), the strong form changes with the body, and an empty file gets no etag at all
- `Name`, `bytesToStr`, `strToBytes`: the empty-input branches

Still short of 100%: `Config.Valid` at 88.9% (the non-`ErrNotExist` stat error is not portably reachable) and `SetEtag` at 94.7% (the `io.ReadAll` failure path). Both would need filesystem fault injection to reach, which is not worth the machinery here.

CI gains the coverage guard. Both tiers and their coverpkg were already correct, so nothing else changed there — the guard sees 144 blocks against a floor of 10.
